### PR TITLE
fix: ignore HTTPS error in HTTPX

### DIFF
--- a/uzen/services/fake_browser.py
+++ b/uzen/services/fake_browser.py
@@ -39,11 +39,12 @@ class FakeBrowser:
             Snapshot -- Snapshot ORM instance
         """
         submitted_url: str = url
+        verify = not ignore_https_errors
 
         try:
             # default timeout = 30 seconds
             timeout = int(timeout / 1000) if timeout is not None else 30
-            client = httpx.AsyncClient()
+            client = httpx.AsyncClient(verify=verify)
             res = await client.get(
                 url,
                 headers={


### PR DESCRIPTION
Ignore HTTPS errors in HTTPX if ignore_https_erros is True