### PR TITLE
fix: catch AttributeError

### DIFF
--- a/uzen/services/rdap.py
+++ b/uzen/services/rdap.py
@@ -21,5 +21,5 @@ class RDAP:
                 "country": country,
                 "description": description,
             }
-        except BaseIpwhoisException:
+        except (BaseIpwhoisException, AttributeError):
             return {}


### PR DESCRIPTION
Change to catch AttributeError because there is a possibility that `lookup_rdap` raises AttributeError.

```
File "/xxx/.local/lib/python3.8/site-packages/ipwhois/rdap.py", line 554, in parse
self.vars[v] = self.json[v].strip()
AttributeError: 'NoneType' object has no attribute 'strip'
```