### PR TITLE
refactor: update URL validation

### DIFF
--- a/tests/schemas/test_snapshots.py
+++ b/tests/schemas/test_snapshots.py
@@ -1,6 +1,10 @@
 import pytest
 
-from uzen.schemas.snapshots import CreateSnapshotPayload
+from uzen.schemas.snapshots import (
+    BasicAttributes,
+    CreateSnapshotPayload,
+    remove_sharp_and_question_from_tail,
+)
 
 
 def test_create_snapsnot_payload():
@@ -9,3 +13,37 @@ def test_create_snapsnot_payload():
 
     with pytest.raises(ValueError):
         CreateSnapshotPayload(url="http://nope.example.com")
+
+
+def test_basic_attributes():
+    basic = BasicAttributes(
+        url="http://example.com#",
+        submitted_url="http://example.com#",
+        hostname="example.com",
+        ip_address="1.1.1.1",
+        asn="",
+        status=200,
+        body="",
+        sha256="",
+    )
+    assert basic.url == "http://example.com"
+    assert basic.submitted_url == "http://example.com"
+
+    basic = BasicAttributes(
+        url="http://example.com?",
+        submitted_url="http://example.com?",
+        hostname="example.com",
+        ip_address="1.1.1.1",
+        asn="",
+        status=200,
+        body="",
+        sha256="",
+    )
+    assert basic.url == "http://example.com"
+    assert basic.submitted_url == "http://example.com"
+
+
+def test_remove_sharp_and_question_from_tail():
+    assert remove_sharp_and_question_from_tail("foo#") == "foo"
+    assert remove_sharp_and_question_from_tail("foo?") == "foo"
+    assert remove_sharp_and_question_from_tail("foo") == "foo"

--- a/uzen/schemas/snapshots.py
+++ b/uzen/schemas/snapshots.py
@@ -18,6 +18,10 @@ from uzen.services.utils import get_hostname_from_url, get_ip_address_by_hostnam
 # Declare rules related schemas here to prevent circular reference
 
 
+def remove_sharp_and_question_from_tail(v: str) -> str:
+    return v.rstrip("#|?")
+
+
 class BaseRule(Source, Target):
     """Base Pydantic model for Rule
 
@@ -58,6 +62,18 @@ class BasicAttributes(APIModel):
     sha256: str = Field(
         ..., title="SHA256", description="SHA256 hash of HTTP response body"
     )
+
+    @validator(
+        "url", pre=True,
+    )
+    def normalize_url(cls, v: str):
+        return remove_sharp_and_question_from_tail(v)
+
+    @validator(
+        "submitted_url", pre=True,
+    )
+    def normalize_submitted_url(cls, v: str):
+        return remove_sharp_and_question_from_tail(v)
 
 
 class BaseSnapshot(BasicAttributes):


### PR DESCRIPTION
Remove # and ? at the tail of a URL to pass the default Pydantic validator